### PR TITLE
Add pull-request-number to auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -29,4 +29,5 @@ jobs:
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: merge


### PR DESCRIPTION
Specifies the pull request number in the dependabot auto-merge workflow to ensure the correct PR is targeted for automerge.